### PR TITLE
Add py.typed marker file (as defined by PEP 561)

### DIFF
--- a/InquirerPy/py.typed
+++ b/InquirerPy/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The InquirerPy package uses inline types.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 packages = [
   {include = "InquirerPy"}
 ]
+include = ["InquirerPy/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.7"


### PR DESCRIPTION
Addresses https://github.com/kazhala/InquirerPy/issues/45

Adds the `py.typed` file as per PEP 561. This ensures that projects that import InquirerPy can be type checked.