### PR TITLE
Fixed type hint for `execute_async`

### DIFF
--- a/InquirerPy/base/simple.py
+++ b/InquirerPy/base/simple.py
@@ -338,7 +338,7 @@ class BaseSimplePrompt(ABC):
             return result
         return self._filter(result)
 
-    async def execute_async(self) -> None:
+    async def execute_async(self) -> Any:
         """Run the prompt asynchronously and get the result.
 
         Returns:


### PR DESCRIPTION
Fixes #50 

This fixes the incorrect type hint, changed from `None` to `Any`

```diff
- async def execute_async(self) -> None:
+ async def execute_async(self) -> Any:
```