### PR TITLE
Support prompt-toolkit 3.0.47

### DIFF
--- a/tests/prompts/test_confirm.py
+++ b/tests/prompts/test_confirm.py
@@ -12,153 +12,153 @@ from InquirerPy.utils import InquirerPyStyle
 
 
 class TestConfirmPrompt(unittest.TestCase):
-    def setUp(self):
-        self.inp = create_pipe_input()
-
-    def tearDown(self):
-        self.inp.close()
-
     def test_default_false(self):
-        self.inp.send_text("\n")
-        confirm_prompt = ConfirmPrompt(
-            message="hello",
-            style=InquirerPyStyle({"qmark": "bold"}),
-            default=False,
-            qmark="x",
-            output=DummyOutput(),
-            input=self.inp,
-        )
-        result = confirm_prompt.execute()
-        self.assertEqual(result, False)
-        self.assertEqual(confirm_prompt.status["answered"], True)
-        self.assertEqual(confirm_prompt.status["result"], False)
+        with create_pipe_input() as inp:
+            inp.send_text("\n")
+            confirm_prompt = ConfirmPrompt(
+                message="hello",
+                style=InquirerPyStyle({"qmark": "bold"}),
+                default=False,
+                qmark="x",
+                output=DummyOutput(),
+                input=inp,
+            )
+            result = confirm_prompt.execute()
+            self.assertEqual(result, False)
+            self.assertEqual(confirm_prompt.status["answered"], True)
+            self.assertEqual(confirm_prompt.status["result"], False)
 
     def test_default_true(self):
-        self.inp.send_text("\n")
-        confirm_prompt = ConfirmPrompt(
-            message="hello",
-            style=InquirerPyStyle({"qmark": "bold", "answer": "#000000"}),
-            default=True,
-            qmark="x",
-            output=DummyOutput(),
-            input=self.inp,
-        )
-        result = confirm_prompt.execute()
-        self.assertEqual(result, True)
-        self.assertEqual(confirm_prompt.status["answered"], True)
-        self.assertEqual(confirm_prompt.status["result"], True)
+        with create_pipe_input() as inp:
+            inp.send_text("\n")
+            confirm_prompt = ConfirmPrompt(
+                message="hello",
+                style=InquirerPyStyle({"qmark": "bold", "answer": "#000000"}),
+                default=True,
+                qmark="x",
+                output=DummyOutput(),
+                input=inp,
+            )
+            result = confirm_prompt.execute()
+            self.assertEqual(result, True)
+            self.assertEqual(confirm_prompt.status["answered"], True)
+            self.assertEqual(confirm_prompt.status["result"], True)
 
     def test_input_y(self):
-        self.inp.send_text("y")
-        confirm_prompt = ConfirmPrompt(
-            message="hello",
-            style=None,
-            default=True,
-            qmark="?",
-            output=DummyOutput(),
-            input=self.inp,
-        )
-        result = confirm_prompt._session.prompt()
-        self.assertEqual(result, True)
-        self.assertEqual(confirm_prompt.status["answered"], True)
-        self.assertEqual(confirm_prompt.status["result"], True)
+        with create_pipe_input() as inp:
+            inp.send_text("y")
+            confirm_prompt = ConfirmPrompt(
+                message="hello",
+                style=None,
+                default=True,
+                qmark="?",
+                output=DummyOutput(),
+                input=inp,
+            )
+            result = confirm_prompt._session.prompt()
+            self.assertEqual(result, True)
+            self.assertEqual(confirm_prompt.status["answered"], True)
+            self.assertEqual(confirm_prompt.status["result"], True)
 
-        self.inp.send_text("Y")
-        confirm_prompt = ConfirmPrompt(
-            message="hello",
-            style=None,
-            default=True,
-            qmark="?",
-            output=DummyOutput(),
-            input=self.inp,
-        )
-        result = confirm_prompt.execute()
-        self.assertEqual(result, True)
+            inp.send_text("Y")
+            confirm_prompt = ConfirmPrompt(
+                message="hello",
+                style=None,
+                default=True,
+                qmark="?",
+                output=DummyOutput(),
+                input=inp,
+            )
+            result = confirm_prompt.execute()
+            self.assertEqual(result, True)
 
     def test_input_n(self):
-        self.inp.send_text("n")
-        confirm_prompt = ConfirmPrompt(
-            message="hello",
-            style=None,
-            default=True,
-            qmark="?",
-            output=DummyOutput(),
-            input=self.inp,
-        )
-        result = confirm_prompt.execute()
-        self.assertEqual(result, False)
-        self.assertEqual(confirm_prompt.status["answered"], True)
-        self.assertEqual(confirm_prompt.status["result"], False)
+        with create_pipe_input() as inp:
+            inp.send_text("n")
+            confirm_prompt = ConfirmPrompt(
+                message="hello",
+                style=None,
+                default=True,
+                qmark="?",
+                output=DummyOutput(),
+                input=inp,
+            )
+            result = confirm_prompt.execute()
+            self.assertEqual(result, False)
+            self.assertEqual(confirm_prompt.status["answered"], True)
+            self.assertEqual(confirm_prompt.status["result"], False)
 
-        self.inp.send_text("N")
-        confirm_prompt = ConfirmPrompt(
-            message="hello",
-            style=None,
-            default=True,
-            qmark="?",
-            output=DummyOutput(),
-            input=self.inp,
-        )
-        result = confirm_prompt.execute()
-        self.assertEqual(result, False)
+            inp.send_text("N")
+            confirm_prompt = ConfirmPrompt(
+                message="hello",
+                style=None,
+                default=True,
+                qmark="?",
+                output=DummyOutput(),
+                input=inp,
+            )
+            result = confirm_prompt.execute()
+            self.assertEqual(result, False)
 
     def test_custom_confirm(self):
-        self.inp.send_text("s")
-        confirm_prompt = ConfirmPrompt(
-            message="hello",
-            style=None,
-            default=True,
-            qmark="?",
-            output=DummyOutput(),
-            input=self.inp,
-            confirm_letter="s",
-        )
-        result = confirm_prompt._session.prompt()
-        self.assertEqual(result, True)
-        self.assertEqual(confirm_prompt.status["answered"], True)
-        self.assertEqual(confirm_prompt.status["result"], True)
+        with create_pipe_input() as inp:
+            inp.send_text("s")
+            confirm_prompt = ConfirmPrompt(
+                message="hello",
+                style=None,
+                default=True,
+                qmark="?",
+                output=DummyOutput(),
+                input=inp,
+                confirm_letter="s",
+            )
+            result = confirm_prompt._session.prompt()
+            self.assertEqual(result, True)
+            self.assertEqual(confirm_prompt.status["answered"], True)
+            self.assertEqual(confirm_prompt.status["result"], True)
 
-        self.inp.send_text("S")
-        confirm_prompt = ConfirmPrompt(
-            message="hello",
-            style=None,
-            default=True,
-            qmark="?",
-            output=DummyOutput(),
-            input=self.inp,
-            confirm_letter="s",
-        )
-        result = confirm_prompt.execute()
-        self.assertEqual(result, True)
+            inp.send_text("S")
+            confirm_prompt = ConfirmPrompt(
+                message="hello",
+                style=None,
+                default=True,
+                qmark="?",
+                output=DummyOutput(),
+                input=inp,
+                confirm_letter="s",
+            )
+            result = confirm_prompt.execute()
+            self.assertEqual(result, True)
 
     def test_custom_reject(self):
-        self.inp.send_text("w")
-        confirm_prompt = ConfirmPrompt(
-            message="hello",
-            style=None,
-            default=False,
-            qmark="?",
-            output=DummyOutput(),
-            input=self.inp,
-            reject_letter="w",
-        )
-        result = confirm_prompt.execute()
-        self.assertEqual(result, False)
-        self.assertEqual(confirm_prompt.status["answered"], True)
-        self.assertEqual(confirm_prompt.status["result"], False)
+        with create_pipe_input() as inp:
+            inp.send_text("w")
+            confirm_prompt = ConfirmPrompt(
+                message="hello",
+                style=None,
+                default=False,
+                qmark="?",
+                output=DummyOutput(),
+                input=inp,
+                reject_letter="w",
+            )
+            result = confirm_prompt.execute()
+            self.assertEqual(result, False)
+            self.assertEqual(confirm_prompt.status["answered"], True)
+            self.assertEqual(confirm_prompt.status["result"], False)
 
-        self.inp.send_text("W")
-        confirm_prompt = ConfirmPrompt(
-            message="hello",
-            style=None,
-            default=True,
-            qmark="?",
-            output=DummyOutput(),
-            input=self.inp,
-            reject_letter="w",
-        )
-        result = confirm_prompt.execute()
-        self.assertEqual(result, False)
+            inp.send_text("W")
+            confirm_prompt = ConfirmPrompt(
+                message="hello",
+                style=None,
+                default=True,
+                qmark="?",
+                output=DummyOutput(),
+                input=inp,
+                reject_letter="w",
+            )
+            result = confirm_prompt.execute()
+            self.assertEqual(result, False)
 
     def test_get_prompt_message(self):
         confirm_prompt = ConfirmPrompt(
@@ -268,28 +268,29 @@ class TestConfirmPrompt(unittest.TestCase):
         prompt.execute()
 
     def test_input_y_async(self):
-        self.inp.send_text("y")
-        confirm_prompt = ConfirmPrompt(
-            message="hello",
-            style=None,
-            default=True,
-            qmark="?",
-            output=DummyOutput(),
-            input=self.inp,
-        )
-        result = asyncio.run(confirm_prompt._run_async())
-        self.assertEqual(result, True)
-        self.assertEqual(confirm_prompt.status["answered"], True)
-        self.assertEqual(confirm_prompt.status["result"], True)
+        with create_pipe_input() as inp:
+            inp.send_text("y")
+            confirm_prompt = ConfirmPrompt(
+                message="hello",
+                style=None,
+                default=True,
+                qmark="?",
+                output=DummyOutput(),
+                input=inp,
+            )
+            result = asyncio.run(confirm_prompt._run_async())
+            self.assertEqual(result, True)
+            self.assertEqual(confirm_prompt.status["answered"], True)
+            self.assertEqual(confirm_prompt.status["result"], True)
 
-        self.inp.send_text("Y")
-        confirm_prompt = ConfirmPrompt(
-            message="hello",
-            style=None,
-            default=True,
-            qmark="?",
-            output=DummyOutput(),
-            input=self.inp,
-        )
-        result = asyncio.run(confirm_prompt.execute_async())
-        self.assertEqual(result, True)
+            inp.send_text("Y")
+            confirm_prompt = ConfirmPrompt(
+                message="hello",
+                style=None,
+                default=True,
+                qmark="?",
+                output=DummyOutput(),
+                input=inp,
+            )
+            result = asyncio.run(confirm_prompt.execute_async())
+            self.assertEqual(result, True)

--- a/tests/prompts/test_input.py
+++ b/tests/prompts/test_input.py
@@ -14,95 +14,93 @@ from InquirerPy.prompts.input import InputPrompt
 
 
 class TestInputPrompt(unittest.TestCase):
-    def setUp(self):
-        self.inp = create_pipe_input()
-
-    def tearDown(self):
-        self.inp.close()
-
     def test_prompt_result(self):
-        self.inp.send_text("hello\n")
-        input_prompt = InputPrompt(
-            message="yes",
-            style=None,
-            default="world",
-            qmark="!",
-            vi_mode=False,
-            input=self.inp,
-            output=DummyOutput(),
-        )
-        result = input_prompt.execute()
-        self.assertEqual(result, "worldhello")
-        self.assertEqual(input_prompt.status["answered"], True)
-        self.assertEqual(input_prompt.status["result"], "worldhello")
-        self.assertEqual(input_prompt.status["skipped"], False)
+        with create_pipe_input() as inp:
+            inp.send_text("hello\n")
+            input_prompt = InputPrompt(
+                message="yes",
+                style=None,
+                default="world",
+                qmark="!",
+                vi_mode=False,
+                input=inp,
+                output=DummyOutput(),
+            )
+            result = input_prompt.execute()
+            self.assertEqual(result, "worldhello")
+            self.assertEqual(input_prompt.status["answered"], True)
+            self.assertEqual(input_prompt.status["result"], "worldhello")
+            self.assertEqual(input_prompt.status["skipped"], False)
 
     def test_prompt_filter(self):
-        self.inp.send_text("hello\n")
-        input_prompt = InputPrompt(
-            message="yes",
-            style=None,
-            default="world",
-            qmark="!",
-            vi_mode=False,
-            input=self.inp,
-            output=DummyOutput(),
-            filter=lambda x: x * 2,
-            transformer=lambda _: "what",
-        )
-        result = input_prompt.execute()
-        self.assertEqual(result, "worldhelloworldhello")
-        self.assertEqual(input_prompt.status["answered"], True)
-        self.assertEqual(input_prompt.status["result"], "worldhello")
-        self.assertEqual(
-            input_prompt._get_prompt_message(),
-            [
-                ("class:answermark", "?"),
-                ("class:answered_question", " yes"),
-                ("class:answer", " what"),
-            ],
-        )
+        with create_pipe_input() as inp:
+            inp.send_text("hello\n")
+            input_prompt = InputPrompt(
+                message="yes",
+                style=None,
+                default="world",
+                qmark="!",
+                vi_mode=False,
+                input=inp,
+                output=DummyOutput(),
+                filter=lambda x: x * 2,
+                transformer=lambda _: "what",
+            )
+            result = input_prompt.execute()
+            self.assertEqual(result, "worldhelloworldhello")
+            self.assertEqual(input_prompt.status["answered"], True)
+            self.assertEqual(input_prompt.status["result"], "worldhello")
+            self.assertEqual(
+                input_prompt._get_prompt_message(),
+                [
+                    ("class:answermark", "?"),
+                    ("class:answered_question", " yes"),
+                    ("class:answer", " what"),
+                ],
+            )
 
     def test_prompt_result_multiline(self):
-        self.inp.send_text("hello\nworld\nfoo\nboo\x1b\r")
-        input_prompt = InputPrompt(
-            message="yes",
-            style=None,
-            default="",
-            qmark="!",
-            vi_mode=False,
-            input=self.inp,
-            output=DummyOutput(),
-            multiline=True,
-        )
-        result = input_prompt.execute()
-        self.assertEqual(result, "hello\nworld\nfoo\nboo")
-        self.assertEqual(input_prompt.status["answered"], True)
-        self.assertEqual(input_prompt.status["result"], "hello\nworld\nfoo\nboo")
-        self.assertEqual(input_prompt.status["skipped"], False)
+        with create_pipe_input() as inp:
+            inp.send_text("hello\nworld\nfoo\nboo\x1b\r")
+            input_prompt = InputPrompt(
+                message="yes",
+                style=None,
+                default="",
+                qmark="!",
+                vi_mode=False,
+                input=inp,
+                output=DummyOutput(),
+                multiline=True,
+            )
+            result = input_prompt.execute()
+            self.assertEqual(result, "hello\nworld\nfoo\nboo")
+            self.assertEqual(input_prompt.status["answered"], True)
+            self.assertEqual(input_prompt.status["result"], "hello\nworld\nfoo\nboo")
+            self.assertEqual(input_prompt.status["skipped"], False)
 
     def test_prompt_completion(self):
-        input_prompt = InputPrompt(
-            message="yes",
-            style=None,
-            default="",
-            qmark="!",
-            vi_mode=False,
-            input=self.inp,
-            output=DummyOutput(),
-            multiline=True,
-            completer={"hello": None, "hey": None, "what": None},
-        )
+        with create_pipe_input() as inp:
+            input_prompt = InputPrompt(
+                message="yes",
+                style=None,
+                default="",
+                qmark="!",
+                vi_mode=False,
+                input=inp,
+                output=DummyOutput(),
+                multiline=True,
+                completer={"hello": None, "hey": None, "what": None},
+            )
 
-        completer = input_prompt._completer
-        doc_text = "he"
-        doc = Document(doc_text, len(doc_text))
-        event = CompleteEvent()
-        completions = [
-            completion.text
-            for completion in list(completer.get_completions(doc, event))  # type: ignore
-        ]
-        self.assertEqual(sorted(completions), ["hello", "hey"])
+            completer = input_prompt._completer
+            doc_text = "he"
+            doc = Document(doc_text, len(doc_text))
+            event = CompleteEvent()
+            completions = [
+                completion.text
+                for completion in list(completer.get_completions(doc, event))  # type: ignore
+            ]
+            self.assertEqual(sorted(completions), ["hello", "hey"])
 
     def test_prompt_message_multiline(self):
         input_prompt = InputPrompt(
@@ -266,18 +264,19 @@ class TestInputPrompt(unittest.TestCase):
             )
 
     def test_prompt_result_async(self):
-        self.inp.send_text("hello\n")
-        input_prompt = InputPrompt(
-            message="yes",
-            style=None,
-            default="world",
-            qmark="!",
-            vi_mode=False,
-            input=self.inp,
-            output=DummyOutput(),
-        )
-        result = asyncio.run(input_prompt.execute_async())
-        self.assertEqual(result, "worldhello")
-        self.assertEqual(input_prompt.status["answered"], True)
-        self.assertEqual(input_prompt.status["result"], "worldhello")
-        self.assertEqual(input_prompt.status["skipped"], False)
+        with create_pipe_input() as inp:
+            inp.send_text("hello\n")
+            input_prompt = InputPrompt(
+                message="yes",
+                style=None,
+                default="world",
+                qmark="!",
+                vi_mode=False,
+                input=inp,
+                output=DummyOutput(),
+            )
+            result = asyncio.run(input_prompt.execute_async())
+            self.assertEqual(result, "worldhello")
+            self.assertEqual(input_prompt.status["answered"], True)
+            self.assertEqual(input_prompt.status["result"], "worldhello")
+            self.assertEqual(input_prompt.status["skipped"], False)


### PR DESCRIPTION
I'm packaging InquirerPy in Debian, which has prompt-toolkit 3.0.47. With this version of prompt-toolkit, tests of InquirerPy are broken. This patch fixes them all.